### PR TITLE
Managed length in _sh_read_data_raw_get

### DIFF
--- a/iis2iclx_reg.c
+++ b/iis2iclx_reg.c
@@ -6114,16 +6114,22 @@ int32_t iis2iclx_mlc_out_get(const stmdev_ctx_t *ctx, uint8_t *buff)
   *
   */
 int32_t iis2iclx_sh_read_data_raw_get(const stmdev_ctx_t *ctx,
-                                      iis2iclx_emb_sh_read_t *val)
+                                      iis2iclx_emb_sh_read_t *val, uint16_t len)
 {
   int32_t ret;
+
+  /* Check on registers SENSOR_HUB_X range */
+  if (len > 18)
+  {
+    ret = -22; /* -EINVAL */
+    goto exit;
+  }
 
   ret = iis2iclx_mem_bank_set(ctx, IIS2ICLX_SENSOR_HUB_BANK);
 
   if (ret == 0)
   {
-    ret = iis2iclx_read_reg(ctx, IIS2ICLX_SENSOR_HUB_1, (uint8_t *)val,
-                            18);
+    ret = iis2iclx_read_reg(ctx, IIS2ICLX_SENSOR_HUB_1, (uint8_t *)val, len);
   }
 
   if (ret == 0)
@@ -6131,6 +6137,7 @@ int32_t iis2iclx_sh_read_data_raw_get(const stmdev_ctx_t *ctx,
     ret = iis2iclx_mem_bank_set(ctx, IIS2ICLX_USER_BANK);
   }
 
+exit:
   return ret;
 }
 
@@ -6837,8 +6844,9 @@ int32_t iis2iclx_sh_slv0_cfg_read(const stmdev_ctx_t *ctx,
   {
     slv0_add.slave0 = (uint8_t) val->slv_add >> 1;
     slv0_add.rw_0 = 1;
+
     ret = iis2iclx_write_reg(ctx, IIS2ICLX_SLV0_ADD,
-                             (uint8_t *) & (slv0_add), 1);
+                             (uint8_t*)&slv0_add, 1);
   }
 
   if (ret == 0)

--- a/iis2iclx_reg.c
+++ b/iis2iclx_reg.c
@@ -6794,7 +6794,7 @@ int32_t iis2iclx_sh_cfg_write(const stmdev_ctx_t *ctx,
 
   if (ret == 0)
   {
-    slv0_add.slave0 = (uint8_t)(val->slv0_add >> 1);
+    slv0_add.slave0 = (uint8_t)val->slv0_add;
     slv0_add.rw_0 = 0;
     ret = iis2iclx_write_reg(ctx, IIS2ICLX_SLV0_ADD,
                              (uint8_t *) & (slv0_add), 1);

--- a/iis2iclx_reg.h
+++ b/iis2iclx_reg.h
@@ -3152,7 +3152,7 @@ typedef struct
   iis2iclx_sensor_hub_18_t  sh_byte_18;
 } iis2iclx_emb_sh_read_t;
 int32_t iis2iclx_sh_read_data_raw_get(const stmdev_ctx_t *ctx,
-                                      iis2iclx_emb_sh_read_t *val);
+                                      iis2iclx_emb_sh_read_t *val, uint16_t len);
 
 typedef enum
 {


### PR DESCRIPTION
I need to connect two iis2iclx using the "sensor hub" functionality in this configuration:

STM32XXXX -> SPI -> SENSOR- > I2C (SensorHub) -> SENSOR

By doing this I started with another example of "Sensor Hub".  [lsm6dsox_sh_fifo_lps22hh.c](https://github.com/Tecnosoft/STMems_Standard_C_drivers/blob/master/lsm6dsox_STdC/examples/lsm6dsox_sh_fifo_lps22hh.c)  

By adapting the "_read function_", on the sensor hub side from the example  above it should be as follow:

```
static int32_t iis2iclx_read_iis2iclx_cx(void *ctx, uint8_t reg,
                                        uint8_t *data, uint16_t len)
{
  iis2iclx_sh_cfg_read_t sh_cfg_read;
  int16_t data_raw_acceleration[3];
  int32_t ret;
  uint8_t drdy;
  iis2iclx_status_master_t master_status;
  /* Disable accelerometer. */
  iis2iclx_xl_data_rate_set(&ag_ctx, IIS2ICLX_XL_ODR_OFF);
  /* Configure Sensor Hub to read LPS22HH. */
  sh_cfg_read.slv_add = (IIS2ICLX_I2C_ADD_L & 0xFEU) >> 1; /* 7bit I2C address */
  sh_cfg_read.slv_subadd = reg;
  sh_cfg_read.slv_len = len;
  ret = iis2iclx_sh_slv0_cfg_read(&ag_ctx, &sh_cfg_read);
  iis2iclx_sh_slave_connected_set(&ag_ctx, IIS2ICLX_SLV_0);
  /* Enable I2C Master and I2C master. */
  iis2iclx_sh_master_set(&ag_ctx, PROPERTY_ENABLE);
  /* Enable accelerometer to trigger Sensor Hub operation. */
  iis2iclx_xl_data_rate_set(&ag_ctx, IIS2ICLX_XL_ODR_104Hz);
  /* Wait Sensor Hub operation flag set. */
  iis2iclx_acceleration_raw_get(&ag_ctx, data_raw_acceleration);

  do {
    HAL_Delay(20);
    iis2iclx_xl_flag_data_ready_get(&ag_ctx, &drdy);
  } while (!drdy);

  do {
    //HAL_Delay(20);
    iis2iclx_sh_status_get(&ag_ctx, &master_status);
  } while (!master_status.sens_hub_endop);

  /* Disable I2C master and XL(trigger). */
  iis2iclx_sh_master_set(&ag_ctx, PROPERTY_DISABLE);
  iis2iclx_xl_data_rate_set(&ag_ctx, IIS2ICLX_XL_ODR_OFF);
  /* Read SensorHub registers. */
  iis2iclx_sh_read_data_raw_get(&ag_ctx, (iis2iclx_emb_sh_read_t *)data);
  return ret;
}
````

This function is typically used by others API (ie.` _device_id_get`) and the input argument `uint8_t *data` is typically an array of size `uint16_t len` that is (frequently < 18) but the call 
` iis2iclx_sh_read_data_raw_get(&ag_ctx, (iis2iclx_emb_sh_read_t *)data);` always overwrite 18 bytes.

Therefore the patch adds a check in `iis2iclx_sh_read_data_raw_get` to avoid writing outside the bounds of the `uint8_t *data` array.

